### PR TITLE
Rename module to generative-commit-message-for-ai-tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Thank you for your interest in contributing to this project!
 Clone the repository:
 
 ```sh
-git clone https://github.com/UNILORN/generative-commit-message-for-bedrock.git
-cd generative-commit-message-for-bedrock
+git clone https://github.com/UNILORN/generative-commit-message-for-ai-tool.git
+cd generative-commit-message-for-ai-tool
 ```
 
 Build the project:

--- a/README.en.md
+++ b/README.en.md
@@ -26,6 +26,19 @@ go install github.com/UNILORN/generative-commit-message-for-ai-tool@v1.0.0
 
 The binary will be installed to `$GOPATH/bin`. Make sure this directory is in your `PATH`.
 
+#### Rename to Shorter Name (Optional)
+
+If the command name feels too long, you can rename it after installation:
+
+```sh
+# Rename to gcm
+mv $(go env GOPATH)/bin/generate-auto-commit-message $(go env GOPATH)/bin/gcm
+
+# Usage example
+git add .
+gcm
+```
+
 ### Download Pre-built Binaries
 
 Download the latest release from [GitHub Releases](https://github.com/UNILORN/generative-commit-message-for-ai-tool/releases) for your platform (Linux, macOS, Windows).

--- a/README.en.md
+++ b/README.en.md
@@ -18,17 +18,17 @@ AI-powered commit message generator that analyzes your Git staged changes and ge
 
 ```sh
 # Install latest version
-go install github.com/UNILORN/generative-commit-message-for-bedrock@latest
+go install github.com/UNILORN/generative-commit-message-for-ai-tool@latest
 
 # Install specific version (e.g., v1.0.0)
-go install github.com/UNILORN/generative-commit-message-for-bedrock@v1.0.0
+go install github.com/UNILORN/generative-commit-message-for-ai-tool@v1.0.0
 ```
 
 The binary will be installed to `$GOPATH/bin`. Make sure this directory is in your `PATH`.
 
 ### Download Pre-built Binaries
 
-Download the latest release from [GitHub Releases](https://github.com/UNILORN/generative-commit-message-for-bedrock/releases) for your platform (Linux, macOS, Windows).
+Download the latest release from [GitHub Releases](https://github.com/UNILORN/generative-commit-message-for-ai-tool/releases) for your platform (Linux, macOS, Windows).
 
 ### Check Version
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ Gitのステージング済み変更を分析し、AIを使用して意味のあ
 
 ```sh
 # 最新版をインストール
-go install github.com/UNILORN/generative-commit-message-for-bedrock@latest
+go install github.com/UNILORN/generative-commit-message-for-ai-tool@latest
 
 # 特定のバージョンをインストール（例: v1.0.0）
-go install github.com/UNILORN/generative-commit-message-for-bedrock@v1.0.0
+go install github.com/UNILORN/generative-commit-message-for-ai-tool@v1.0.0
 ```
 
 バイナリは `$GOPATH/bin` にインストールされます。このディレクトリが `PATH` に含まれていることを確認してください。
 
 ### ビルド済みバイナリをダウンロード
 
-各プラットフォーム（Linux、macOS、Windows）向けのビルド済みバイナリは [GitHub Releases](https://github.com/UNILORN/generative-commit-message-for-bedrock/releases) からダウンロードできます。
+各プラットフォーム（Linux、macOS、Windows）向けのビルド済みバイナリは [GitHub Releases](https://github.com/UNILORN/generative-commit-message-for-ai-tool/releases) からダウンロードできます。
 
 ### バージョン確認
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ go install github.com/UNILORN/generative-commit-message-for-ai-tool@v1.0.0
 
 バイナリは `$GOPATH/bin` にインストールされます。このディレクトリが `PATH` に含まれていることを確認してください。
 
+#### 短い名前にリネーム（オプション）
+
+コマンド名が長いと感じる場合は、インストール後に短い名前にリネームできます：
+
+```sh
+# gcm にリネーム
+mv $(go env GOPATH)/bin/generate-auto-commit-message $(go env GOPATH)/bin/gcm
+
+# 使用例
+git add .
+gcm
+```
+
 ### ビルド済みバイナリをダウンロード
 
 各プラットフォーム（Linux、macOS、Windows）向けのビルド済みバイナリは [GitHub Releases](https://github.com/UNILORN/generative-commit-message-for-ai-tool/releases) からダウンロードできます。

--- a/bedrock/client.go
+++ b/bedrock/client.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/client"
-	appconfig "github.com/UNILORN/generative-commit-message-for-bedrock/config"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	appconfig "github.com/UNILORN/generative-commit-message-for-ai-tool/config"
 )
 
 // Client represents an AWS Bedrock client

--- a/claude/client.go
+++ b/claude/client.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/UNILORN/generative-commit-message-for-bedrock/client"
-	appconfig "github.com/UNILORN/generative-commit-message-for-bedrock/config"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	appconfig "github.com/UNILORN/generative-commit-message-for-ai-tool/config"
 )
 
 // Client represents a Claude API client

--- a/claudecode/client.go
+++ b/claudecode/client.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/UNILORN/generative-commit-message-for-bedrock/client"
-	appconfig "github.com/UNILORN/generative-commit-message-for-bedrock/config"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	appconfig "github.com/UNILORN/generative-commit-message-for-ai-tool/config"
 )
 
 // Client represents a Claude Code client

--- a/copilotcli/client.go
+++ b/copilotcli/client.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/UNILORN/generative-commit-message-for-bedrock/client"
-	appconfig "github.com/UNILORN/generative-commit-message-for-bedrock/config"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	appconfig "github.com/UNILORN/generative-commit-message-for-ai-tool/config"
 )
 
 // Client represents a Copilot CLI client

--- a/geminicli/client.go
+++ b/geminicli/client.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/UNILORN/generative-commit-message-for-bedrock/client"
-	appconfig "github.com/UNILORN/generative-commit-message-for-bedrock/config"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	appconfig "github.com/UNILORN/generative-commit-message-for-ai-tool/config"
 )
 
 // Client represents a Gemini CLI client

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/UNILORN/generative-commit-message-for-bedrock
+module github.com/UNILORN/generative-commit-message-for-ai-tool
 
 go 1.23.4
 

--- a/main.go
+++ b/main.go
@@ -8,15 +8,15 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/UNILORN/generative-commit-message-for-bedrock/bedrock"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/claude"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/claudecode"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/client"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/config"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/copilotcli"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/geminicli"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/git"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/message"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/bedrock"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/claude"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/claudecode"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/config"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/copilotcli"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/geminicli"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/git"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/message"
 )
 
 func main() {

--- a/message/generator.go
+++ b/message/generator.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/UNILORN/generative-commit-message-for-bedrock/client"
-	"github.com/UNILORN/generative-commit-message-for-bedrock/git"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/git"
 )
 
 // Generate generates a commit message based on the provided diff


### PR DESCRIPTION
名称が異なっていたため修正。

またコマンドが長い為、 `gcm` コマンドで実行出来るようにREADMEを修正