### PR TITLE
feat: add GitHub Copilot SDK provider (copilotsdk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 generate-auto-commit-message
+generative-commit-message-for-ai-tool
 
 # Test binary, built with `go test -c`
 *.test

--- a/copilotsdk/client.go
+++ b/copilotsdk/client.go
@@ -1,0 +1,104 @@
+package copilotsdk
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
+	appconfig "github.com/UNILORN/generative-commit-message-for-ai-tool/config"
+)
+
+// Client represents a Copilot SDK client
+type Client struct {
+	model string
+}
+
+// Ensure Client implements the AIClient interface
+var _ client.AIClient = (*Client)(nil)
+
+// NewClient creates a new Copilot SDK client
+func NewClient(model string) (*Client, error) {
+	// Set default model if not provided
+	if model == "" {
+		model = "gpt-4.1"
+	}
+
+	return &Client{
+		model: model,
+	}, nil
+}
+
+// GenerateCommitMessage generates a commit message based on the provided diff
+func (c *Client) GenerateCommitMessage(diff string, branch string) (string, error) {
+	// Get config and build prompt
+	cfg := appconfig.Get()
+	prompt := cfg.BuildPromptEnglish(branch, diff)
+
+	// Create Copilot client
+	copilotClient := copilot.NewClient(nil)
+
+	// Start the client (this starts the Copilot CLI server)
+	if err := copilotClient.Start(); err != nil {
+		return "", fmt.Errorf("failed to start copilot client: %w", err)
+	}
+	defer copilotClient.Stop()
+
+	// Create a session with the specified model
+	session, err := copilotClient.CreateSession(&copilot.SessionConfig{
+		Model: c.model,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create session: %w", err)
+	}
+	defer session.Destroy()
+
+	// Send the prompt and wait for the response
+	response, err := session.SendAndWait(copilot.MessageOptions{
+		Prompt: prompt,
+	}, 120*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("failed to send message: %w", err)
+	}
+
+	if response == nil || response.Data.Content == nil {
+		return "", fmt.Errorf("empty response from copilot SDK")
+	}
+
+	responseText := strings.TrimSpace(*response.Data.Content)
+	if responseText == "" {
+		return "", fmt.Errorf("empty response from copilot SDK")
+	}
+
+	// Get list of Semantic Release prefixes from config
+	prefixes := cfg.GetPrefixList()
+
+	// Try to find the first line that starts with a Semantic Release prefix
+	lines := strings.Split(responseText, "\n")
+	startIdx := -1
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(trimmed, prefix) {
+				startIdx = i
+				break
+			}
+		}
+		if startIdx >= 0 {
+			break
+		}
+	}
+
+	// If we found a line starting with a prefix, extract from there
+	if startIdx >= 0 {
+		commitLines := lines[startIdx:]
+		commitMessage := strings.Join(commitLines, "\n")
+		return strings.TrimSpace(commitMessage), nil
+	}
+
+	// Fallback: return the whole response
+	return responseText, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.9
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.26.1
+	github.com/github/copilot-sdk/go v0.1.20
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -22,4 +23,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.17 // indirect
 	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,12 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.17 h1:PZV5W8yk4OtH1JAuhV2PXwwO9v5
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.17/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/github/copilot-sdk/go v0.1.20 h1:r2+Nzr0DS7abF4499PAjsbdc9170OUEeZkic7sUR7BU=
+github.com/github/copilot-sdk/go v0.1.20/go.mod h1:0SYT+64k347IDT0Trn4JHVFlUhPtGSE6ab479tU/+tY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -65,8 +65,8 @@ func printHelp() {
 	fmt.Println("  bedrock    - AWS Bedrock (requires AWS credentials)")
 	fmt.Println("  claude     - Claude API (requires ANTHROPIC_API_KEY environment variable)")
 	fmt.Println("  geminicli  - Local Gemini CLI (requires 'gemini' command in PATH)")
-	fmt.Println("  copilotcli - Local Copilot CLI (requires 'copilot' command in PATH)")
-	fmt.Println("  copilotsdk - GitHub Copilot SDK (requires Copilot CLI installed and authenticated)")
+	fmt.Println("  copilotcli - Copilot CLI direct execution (runs 'copilot' command)")
+	fmt.Println("  copilotsdk - Copilot SDK programmatic access (uses SDK for session management)")
 	fmt.Println("  claudecode - Claude Code CLI (requires 'claude' command in PATH)")
 	fmt.Println("\nAuto-detection:")
 	fmt.Println("  If provider is not specified, it will be auto-detected based on available tools/credentials")
@@ -162,7 +162,7 @@ func runGenerate(args []string) {
 		} else if *provider == "copilotcli" {
 			*modelID = "claude-sonnet-4.5"
 		} else if *provider == "copilotsdk" {
-			*modelID = "gpt-4.1"
+			*modelID = "gpt-4o"
 		} else if *provider == "claudecode" {
 			*modelID = "claude-sonnet-4.5"
 		}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/UNILORN/generative-commit-message-for-ai-tool/client"
 	"github.com/UNILORN/generative-commit-message-for-ai-tool/config"
 	"github.com/UNILORN/generative-commit-message-for-ai-tool/copilotcli"
+	"github.com/UNILORN/generative-commit-message-for-ai-tool/copilotsdk"
 	"github.com/UNILORN/generative-commit-message-for-ai-tool/geminicli"
 	"github.com/UNILORN/generative-commit-message-for-ai-tool/git"
 	"github.com/UNILORN/generative-commit-message-for-ai-tool/message"
@@ -50,7 +51,7 @@ func printHelp() {
 	generateFlags := flag.NewFlagSet("generate", flag.ExitOnError)
 	generateFlags.String("model", "", "Model ID (default depends on provider)")
 	generateFlags.String("region", "us-east-1", "AWS region (for bedrock provider)")
-	generateFlags.String("provider", "", "AI provider: 'bedrock', 'claude', 'geminicli', 'copilotcli', or 'claudecode' (auto-detected if not specified)")
+	generateFlags.String("provider", "", "AI provider: 'bedrock', 'claude', 'geminicli', 'copilotcli', 'copilotsdk', or 'claudecode' (auto-detected if not specified)")
 	generateFlags.String("config", "", "Path to config file (uses embedded default if not specified)")
 	generateFlags.Bool("verbose", false, "Enable verbose output")
 	generateFlags.PrintDefaults()
@@ -65,6 +66,7 @@ func printHelp() {
 	fmt.Println("  claude     - Claude API (requires ANTHROPIC_API_KEY environment variable)")
 	fmt.Println("  geminicli  - Local Gemini CLI (requires 'gemini' command in PATH)")
 	fmt.Println("  copilotcli - Local Copilot CLI (requires 'copilot' command in PATH)")
+	fmt.Println("  copilotsdk - GitHub Copilot SDK (requires Copilot CLI installed and authenticated)")
 	fmt.Println("  claudecode - Claude Code CLI (requires 'claude' command in PATH)")
 	fmt.Println("\nAuto-detection:")
 	fmt.Println("  If provider is not specified, it will be auto-detected based on available tools/credentials")
@@ -116,7 +118,7 @@ func runGenerate(args []string) {
 	generateFlags := flag.NewFlagSet("generate", flag.ExitOnError)
 	modelID := generateFlags.String("model", "", "Model ID (default depends on provider)")
 	region := generateFlags.String("region", "us-east-1", "AWS region (for bedrock provider)")
-	provider := generateFlags.String("provider", "", "AI provider: 'bedrock', 'claude', 'geminicli', 'copilotcli', or 'claudecode' (auto-detected if not specified)")
+	provider := generateFlags.String("provider", "", "AI provider: 'bedrock', 'claude', 'geminicli', 'copilotcli', 'copilotsdk', or 'claudecode' (auto-detected if not specified)")
 	configPath := generateFlags.String("config", "", "Path to config file (uses embedded default if not specified)")
 	verbose := generateFlags.Bool("verbose", false, "Enable verbose output")
 	help := generateFlags.Bool("help", false, "Show help")
@@ -144,8 +146,8 @@ func runGenerate(args []string) {
 
 	// Validate provider
 	*provider = strings.ToLower(*provider)
-	if *provider != "bedrock" && *provider != "claude" && *provider != "geminicli" && *provider != "copilotcli" && *provider != "claudecode" {
-		fmt.Fprintf(os.Stderr, "Error: Invalid provider '%s'. Must be 'bedrock', 'claude', 'geminicli', 'copilotcli', or 'claudecode'\n", *provider)
+	if *provider != "bedrock" && *provider != "claude" && *provider != "geminicli" && *provider != "copilotcli" && *provider != "copilotsdk" && *provider != "claudecode" {
+		fmt.Fprintf(os.Stderr, "Error: Invalid provider '%s'. Must be 'bedrock', 'claude', 'geminicli', 'copilotcli', 'copilotsdk', or 'claudecode'\n", *provider)
 		os.Exit(1)
 	}
 
@@ -159,6 +161,8 @@ func runGenerate(args []string) {
 			*modelID = "gemini-2.5-pro"
 		} else if *provider == "copilotcli" {
 			*modelID = "claude-sonnet-4.5"
+		} else if *provider == "copilotsdk" {
+			*modelID = "gpt-4.1"
 		} else if *provider == "claudecode" {
 			*modelID = "claude-sonnet-4.5"
 		}
@@ -226,6 +230,12 @@ func runGenerate(args []string) {
 		aiClient, err = copilotcli.NewClient(*modelID)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error initializing Copilot CLI client: %v\n", err)
+			os.Exit(1)
+		}
+	} else if *provider == "copilotsdk" {
+		aiClient, err = copilotsdk.NewClient(*modelID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error initializing Copilot SDK client: %v\n", err)
 			os.Exit(1)
 		}
 	} else if *provider == "claudecode" {


### PR DESCRIPTION
Add a new AI provider that uses the GitHub Copilot SDK for programmatic
access to Copilot CLI. This provides an alternative to the existing
copilotcli provider which executes the CLI directly.

- Add copilotsdk package with Client implementation
- Add copilotsdk as a new provider option in main.go
- Default model for copilotsdk is gpt-4.1

https://claude.ai/code/session_01Kaics1D7UEXnv5B5yqocbz