### PR TITLE
fix: 廃止されたモデルIDを最新バージョンに更新して400エラーを解消

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,11 @@ The codebase follows a clean modular architecture with three main packages:
 
 ### For Claude API (Recommended for API access)
 - Requires `ANTHROPIC_API_KEY` environment variable
-- Default model: `claude-3-5-sonnet-20241022`
+- Default model: `claude-sonnet-4-6`
 
 ### For AWS Bedrock
 - Requires AWS credentials configured (via AWS Profile, environment variables, or IAM roles)
-- Default model: `anthropic.claude-3-sonnet-20240229-v1:0` in `us-east-1` region
+- Default model: `anthropic.claude-sonnet-4-5-20250929-v1:0` in `us-east-1` region
 
 Must be run from within a Git repository with staged changes.
 

--- a/README.en.md
+++ b/README.en.md
@@ -107,7 +107,7 @@ generate-auto-commit-message --provider copilotcli --model "gpt-5"
 export ANTHROPIC_API_KEY="your-api-key"
 
 git add .
-generate-auto-commit-message --provider claude --model "claude-3-5-sonnet-20241022"
+generate-auto-commit-message --provider claude --model "claude-sonnet-4-6"
 ```
 
 #### AWS Bedrock
@@ -118,7 +118,7 @@ aws sso login --profile="bedrock"
 export AWS_PROFILE="bedrock"
 
 git add .
-generate-auto-commit-message --provider bedrock --model "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+generate-auto-commit-message --provider bedrock --model "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 ```
 
 ### Example Output

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ generate-auto-commit-message --provider copilotcli --model "gpt-5"
 export ANTHROPIC_API_KEY="your-api-key"
 
 git add .
-generate-auto-commit-message --provider claude --model "claude-3-5-sonnet-20241022"
+generate-auto-commit-message --provider claude --model "claude-sonnet-4-6"
 ```
 
 #### AWS Bedrock
@@ -118,7 +118,7 @@ aws sso login --profile="bedrock"
 export AWS_PROFILE="bedrock"
 
 git add .
-generate-auto-commit-message --provider bedrock --model "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+generate-auto-commit-message --provider bedrock --model "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 ```
 
 ### 実行例

--- a/main.go
+++ b/main.go
@@ -154,9 +154,9 @@ func runGenerate(args []string) {
 	// Set default model ID based on provider
 	if *modelID == "" {
 		if *provider == "bedrock" {
-			*modelID = "anthropic.claude-3-sonnet-20240229-v1:0"
+			*modelID = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 		} else if *provider == "claude" {
-			*modelID = "claude-3-5-sonnet-20241022"
+			*modelID = "claude-sonnet-4-6"
 		} else if *provider == "geminicli" {
 			*modelID = "gemini-2.5-pro"
 		} else if *provider == "copilotcli" {


### PR DESCRIPTION
claude-3-5-sonnet-20241022は2025年10月28日に廃止されており、このモデルへの
APIリクエストは400エラーを返す。また、bedrockのデフォルトモデルも2年以上前の
古いバージョンのため、最新の利用可能なモデルに更新する。

- claude provider: claude-3-5-sonnet-20241022 → claude-sonnet-4-6
- bedrock provider: anthropic.claude-3-sonnet-20240229-v1:0 → anthropic.claude-sonnet-4-5-20250929-v1:0
- README.md, README.en.md, CLAUDE.mdのモデル参照も同様に更新

https://claude.ai/code/session_01GGbtjYXHoJJHqUhRVgy5yo